### PR TITLE
Allow execution while running a manual command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,27 @@ With the plugin installed you can now use the new configuration options inside o
 }
 ```
 
+### Usage with run-script:
+`"env-map": "auto"` will automatically apply to any Composer install or update events that include a call to
+`Incenteev/ParameterHandler`. However, to work during other events or manual script execution you must explicitly add
+the call to buildMap in your scripts object before the buildParameters call. e.g.
+```
+"scripts": {
+    "update-parameters": [
+        "Datto\\Composer\\ParameterAutoEnv\\AutoEnvPlugin::buildMap",
+        "Incenteev\\ParameterHandler\\ScriptHandler::buildParameters"
+    ],
+    "post-install-cmd": [
+        "@update-parameters"
+    ],
+    "post-update-cmd": [
+        "@update-parameters"
+    ]
+}
+```
+
+Execution will now function correctly when running `composer run-script update-parameters`
+
 
 ## Environment variable names
 


### PR DESCRIPTION
- Don't trigger the auto-env checks on events that the Incenteev\ParameterHandler script is not being called in.
- Allow & document the use of auto-env checks explicitly in the composer.json scripts section.

This will change the behaviour of auto-env to **not** run environment checks on Composer events when the ParameterHandler is not triggered. I consider this a bugfix but we could equally put it down as a backwards incompatibility and increment the major version.